### PR TITLE
Convert coach agent to tool-based architecture

### DIFF
--- a/cloud-run/coach/main.py
+++ b/cloud-run/coach/main.py
@@ -1,13 +1,13 @@
 """Muscle Growth Coach - Cloud Run Job.
 
-Trello-based coaching agent. Two modes:
-- morning: Read board (spec + card history), generate exercise + nutrition cards
-- reply: Read board desc + card comments, respond to user's comment
+Trello-based coaching agent using an agentic tool-use loop. Two modes:
+- morning: Read board summary, create exercise + nutrition + forum cards via tools
+- reply: Read card context, respond to user's comment via tools
 
-Board has three lists: Exercise, Nutrition, Forum.
+Board has four lists: Exercise, Nutrition, Forum, Memories.
 
 Reads COACH_MODE from environment:
-- "morning": Create daily exercise card + nutrition card
+- "morning": Create daily exercise card + nutrition card + forum card
 - "reply": Process user comment on a card and respond
 """
 
@@ -254,58 +254,6 @@ def _comment_role(text):
     return "Coach" if text.startswith(COACH_PREFIX) else "Client"
 
 
-def read_board_context(trello):
-    """Read full board context: all non-archived cards with their comments.
-
-    Returns a formatted string with all cards and conversations,
-    including which list each card belongs to, card IDs, and checklist items.
-    Excludes Memories list cards (read separately via read_memories).
-    """
-    cards = trello.get_cards()
-
-    # Build list ID → name mapping
-    lists = trello.get_lists()
-    list_names = {lst["id"]: lst["name"] for lst in lists}
-
-    # Find Memories list ID to exclude those cards
-    memories_id = None
-    for lst in lists:
-        if lst["name"].lower() == "memories":
-            memories_id = lst["id"]
-            break
-
-    lines = []
-    for card in cards:
-        if card.get("idList") == memories_id:
-            continue
-        list_name = list_names.get(card.get("idList"), "Unknown")
-        lines.append(f"### [{list_name}] {card['name']}  (card_id: {card['id']})")
-        if card.get("desc"):
-            lines.append(card["desc"][:500])
-
-        # Include checklist items with IDs and states
-        try:
-            checklists = trello.get_card_checklists(card["id"])
-            for cl in checklists:
-                for item in cl.get("checkItems", []):
-                    state = "x" if item.get("state") == "complete" else " "
-                    lines.append(
-                        f"- [{state}] {item['name']}  (item_id: {item['id']})"
-                    )
-        except Exception:
-            pass  # Skip if checklists fail
-
-        comments = trello.get_card_comments(card["id"])
-        for comment in comments:
-            ts = _utc_to_ct(comment.get("date", ""))
-            text = comment.get("data", {}).get("text", "")
-            role = _comment_role(text)
-            lines.append(f"[{ts}] {role}: {text}")
-        lines.append("")
-
-    return "\n".join(lines)
-
-
 def read_memories(trello):
     """Read all memory cards and their comments from the Memories list."""
     lists = trello.get_lists()
@@ -358,6 +306,35 @@ def read_card_context(trello, card_id):
     return "\n".join(lines)
 
 
+def build_board_summary(trello):
+    """Build lightweight board summary: card titles + IDs + list membership + last_activity.
+
+    Excludes Memories list cards (read separately via read_memories).
+    """
+    cards = trello.get_cards()
+    lists = trello.get_lists()
+    list_names = {lst["id"]: lst["name"] for lst in lists}
+
+    memories_id = None
+    for lst in lists:
+        if lst["name"].lower() == "memories":
+            memories_id = lst["id"]
+            break
+
+    lines = []
+    for card in cards:
+        if card.get("idList") == memories_id:
+            continue
+        list_name = list_names.get(card.get("idList"), "Unknown")
+        last_activity = _utc_to_ct(card.get("dateLastActivity", ""))
+        lines.append(
+            f"- [{list_name}] {card['name']}  "
+            f"(card_id: {card['id']}, last_activity: {last_activity})"
+        )
+
+    return "\n".join(lines)
+
+
 # --- Claude ---
 
 
@@ -367,21 +344,6 @@ def _get_client():
     if not api_key:
         raise ValueError("ANTHROPIC_API_KEY not set")
     return anthropic.Anthropic(api_key=api_key)
-
-
-def _parse_json_response(content):
-    """Parse Claude's JSON response, handling markdown fences."""
-    content = content.strip()
-    if "```" in content:
-        content = content.split("```")[1]
-        if content.startswith("json"):
-            content = content[4:]
-        content = content.strip()
-    if not content.startswith("{"):
-        match = re.search(r"\{", content)
-        if match:
-            content = content[match.start():]
-    return json.loads(content)
 
 
 def apply_spec_update(current_spec, instruction):
@@ -411,259 +373,6 @@ def apply_spec_update(current_spec, instruction):
 - Return ONLY the updated spec text, no commentary or markdown fences"""}],
     )
     return response.content[0].text.strip()
-
-
-def generate_morning_cards(spec, board_context, memories=""):
-    """Generate daily exercise and nutrition cards."""
-    client = _get_client()
-
-    now_ct = datetime.now(tz=CT)
-    day_of_week = now_ct.strftime("%A")
-    date_str = now_ct.strftime("%B %d, %Y")
-    time_str = now_ct.strftime("%-I:%M %p").lower()
-
-    prompt = f"""You are a muscle growth coach managing a client's training via a Trello board.
-Each morning you create cards for the day's training and nutrition.
-
-Today is {day_of_week}, {date_str}. Current time: {time_str} Central.
-
-## Board Structure
-The board has four lists:
-- **Exercise** — one card per workout (title, full routine in description, checklist of exercises)
-- **Nutrition** — cards for meals, grocery runs, supplements (title, description, checklist of items)
-- **Forum** — daily check-in card for open conversation throughout the day
-- **Memories** — long-term memory cards organized by category (one card per topic, comments are individual memories)
-
-## Client Spec (board description — your working plan for this client)
-{spec or "(No spec yet — introduce yourself and ask about their goals in the exercise comment)"}
-
-## Memories (long-term factual reference)
-{memories or "(No memories yet)"}
-
-## Recent Board Activity (all cards and conversations)
-{board_context or "(First interaction — no history yet)"}
-
-## Your Task
-Create today's exercise card, nutrition card, and a Forum check-in card. Consider:
-- What day of the week it is (training day vs rest day per their schedule)
-- What happened in recent conversations (soreness, PRs, skipped meals, injuries)
-- Their current phase/goals from the spec
-- Progressive overload: increment weights/volume based on recent performance
-- Nutrition to support their training (meals, macros, grocery needs)
-
-## Rules
-- Be specific to THEIR program — exercises, weights, sets, reps, rest periods
-- Include warm-up guidance if relevant
-- The exercise comment should be conversational and specific (not generic motivation)
-- Nutrition checklist items should be actionable (meals to eat, items to buy)
-- If the spec is empty, introduce yourself and ask what they're working on
-- On rest days, skip the exercise card (set to null) but still provide nutrition
-- The forum card is a daily check-in — open-ended prompt for the client to message throughout the day
-- The forum comment should be conversational: ask how they're feeling, follow up on yesterday, etc.
-- Exercise or nutrition can be null if not applicable; always create a forum card
-
-## Two-Tier Memory System
-You have two places to store information:
-
-**Spec** (board description) — your working document. Keep it concise:
-- Current training program and schedule
-- Active goals and preferences
-- Plans and decisions that change over time
-- Update via "spec_update_instruction". Also prune stale info, compress daily details into trends, and remove completed one-off tasks.
-
-**Memories** (Memories list) — factual records that accumulate. Store critical facts only:
-- Personal records (PRs, body weight milestones)
-- Injury history and recovery notes
-- Key client info (schedule constraints, equipment access, dietary restrictions)
-- Supplement protocols and changes
-- To add a memory: use a "comment" action on an existing memory card, or "create_card" on the Memories list for a new category.
-- Don't store everything — only facts you'd actually reference later when coaching.
-
-## Board Actions
-You can take actions on existing cards or create new ones. Available actions:
-- {{"action": "archive_card", "card_id": "..."}} — archive a card
-- {{"action": "check_item", "card_id": "...", "item_id": "..."}} — check off a checklist item
-- {{"action": "uncheck_item", "card_id": "...", "item_id": "..."}} — uncheck a checklist item
-- {{"action": "move_card", "card_id": "...", "list": "Exercise|Nutrition|Forum|Memories"}} — move a card
-- {{"action": "comment", "card_id": "...", "text": "..."}} — comment on an existing card
-- {{"action": "update_card", "card_id": "...", "name": "...", "desc": "..."}} — update card name/desc (both optional)
-- {{"action": "create_card", "list": "Exercise|Nutrition|Forum|Memories", "title": "...", "description": "...", "checklist": ["item1", "item2"], "comment": "..."}} — create a new card (description, checklist, comment are optional)
-
-## Output
-Respond with JSON only:
-{{
-    "exercise": {{
-        "title": "{day_of_week}, {date_str} — [Focus Area]",
-        "description": "full markdown workout description",
-        "checklist": ["exercise checklist items like 'Bench Press 4x8 @ 185'"],
-        "comment": "conversational coach message"
-    }},
-    "nutrition": {{
-        "title": "{day_of_week}, {date_str} — Nutrition",
-        "description": "meal plan / nutrition notes in markdown",
-        "checklist": ["actionable items like 'Meal 1: Oatmeal + whey (40g protein)'"]
-    }},
-    "forum": {{
-        "title": "{day_of_week}, {date_str} — Check In",
-        "description": "",
-        "comment": "conversational check-in message"
-    }},
-    "actions": [],
-    "spec_update_instruction": null or "brief description of what to change in the spec"
-}}
-Either "exercise" or "nutrition" can be null if not applicable for today. Always include "forum".
-"actions" is an array of board actions to take (can be empty).
-"spec_update_instruction" is a brief description — NOT the full spec."""
-
-    response = client.messages.create(
-        model=MODEL,
-        max_tokens=8000,
-        messages=[{"role": "user", "content": prompt}],
-    )
-    return _parse_json_response(response.content[0].text)
-
-
-def generate_reply(spec, board_context, card_context, user_comment, card_name, memories=""):
-    """Process user comment and generate reply + optional spec updates."""
-    client = _get_client()
-
-    now_ct = datetime.now(tz=CT)
-    day_of_week = now_ct.strftime("%A")
-    time_str = now_ct.strftime("%-I:%M %p").lower()
-
-    prompt = f"""You are a muscle growth coach communicating with your client via Trello card comments.
-Your client just commented on a card. Read their message and respond helpfully.
-
-Today is {day_of_week}. Current time: {time_str} Central.
-
-## Board Structure
-The board has four lists:
-- **Exercise** — workout cards (one per session)
-- **Nutrition** — meal plans, grocery lists, supplement tracking
-- **Forum** — ongoing discussion topics
-- **Memories** — long-term memory cards organized by category (one card per topic, comments are individual memories)
-
-## Client Spec (board description — your working plan)
-{spec or "(No spec yet)"}
-
-## Memories (long-term factual reference)
-{memories or "(No memories yet)"}
-
-## Full Board Activity (all cards and conversations)
-{board_context or "(No board history yet)"}
-
-## Current Card Context (card: {card_name})
-{card_context or "(No prior conversation on this card)"}
-
-## New Comment from Client
-{user_comment}
-
-## Your Task
-1. Understand what they're telling you or asking
-2. Respond with helpful, specific coaching advice
-3. Update spec and/or memories as needed
-
-## Rules
-- Be conversational but knowledgeable
-- If they report a workout, acknowledge it specifically
-- If they ask a question, give a direct answer then brief explanation
-- If they share a concern (injury, plateau, motivation), address it with empathy and a plan
-
-## Two-Tier Memory System
-You have two places to store information:
-
-**Spec** (board description) — your working document. Keep it concise:
-- Current training program and schedule
-- Active goals and preferences
-- Plans and decisions that change over time
-- Update via "spec_update_instruction". Also prune stale info, compress daily details into trends, and remove completed one-off tasks.
-
-**Memories** (Memories list) — factual records that accumulate. Store critical facts only:
-- Personal records (PRs, body weight milestones)
-- Injury history and recovery notes
-- Key client info (schedule constraints, equipment access, dietary restrictions)
-- Supplement protocols and changes
-- To add a memory: use a "comment" action on an existing memory card, or "create_card" on the Memories list for a new category.
-- Don't store everything — only facts you'd actually reference later when coaching.
-
-## Board Actions
-You can take actions on existing cards or create new ones. Available actions:
-- {{"action": "archive_card", "card_id": "..."}} — archive a card
-- {{"action": "check_item", "card_id": "...", "item_id": "..."}} — check off a checklist item
-- {{"action": "uncheck_item", "card_id": "...", "item_id": "..."}} — uncheck a checklist item
-- {{"action": "move_card", "card_id": "...", "list": "Exercise|Nutrition|Forum|Memories"}} — move a card
-- {{"action": "comment", "card_id": "...", "text": "..."}} — comment on an existing card
-- {{"action": "update_card", "card_id": "...", "name": "...", "desc": "..."}} — update card name/desc (both optional)
-- {{"action": "create_card", "list": "Exercise|Nutrition|Forum|Memories", "title": "...", "description": "...", "checklist": ["item1", "item2"], "comment": "..."}} — create a new card (description, checklist, comment are optional)
-
-Use create_card when the client asks for a new workout plan, meal plan, grocery list, or any other card-worthy content.
-For example, if they say "can you make me a leg day card?", create one on the Exercise list.
-
-## Output
-Respond with JSON only:
-{{
-    "reaction": "emoji shortname reacting to the client's message (e.g. muscle, fire, eyes, tada, heart, thumbsup, thinking_face, saluting_face, clap)",
-    "message": "your reply comment text",
-    "actions": [],
-    "spec_update_instruction": null or "brief description of what to change in the spec"
-}}
-"reaction" is an emoji shortname — pick one that fits your reaction to what they said.
-"actions" is an array of board actions to take (can be empty).
-"spec_update_instruction" is a brief description — NOT the full spec."""
-
-    response = client.messages.create(
-        model=MODEL,
-        max_tokens=8000,
-        messages=[{"role": "user", "content": prompt}],
-    )
-    return _parse_json_response(response.content[0].text)
-
-
-# --- Handlers ---
-
-
-def _execute_actions(trello, trace_id, actions):
-    """Execute board actions returned by the coach."""
-    for action in actions:
-        action_type = action.get("action", "")
-        try:
-            if action_type == "archive_card":
-                trello.archive_card(action["card_id"])
-            elif action_type == "check_item":
-                trello.set_check_item_state(action["card_id"], action["item_id"], "complete")
-            elif action_type == "uncheck_item":
-                trello.set_check_item_state(action["card_id"], action["item_id"], "incomplete")
-            elif action_type == "move_card":
-                list_id = trello.get_list_id(action["list"])
-                trello.move_card(action["card_id"], list_id)
-            elif action_type == "comment":
-                trello.add_comment(action["card_id"], action["text"])
-            elif action_type == "create_card":
-                _create_card_with_checklist(trello, trace_id, action["list"], {
-                    "title": action["title"],
-                    "description": action.get("description", ""),
-                    "checklist": action.get("checklist", []),
-                    "comment": action.get("comment", ""),
-                })
-            elif action_type == "update_card":
-                fields = {}
-                if action.get("name"):
-                    fields["name"] = action["name"]
-                if action.get("desc"):
-                    fields["desc"] = action["desc"]
-                if fields:
-                    trello.update_card(action["card_id"], **fields)
-            else:
-                logger.warning(f"[{trace_id}] Unknown action: {action_type}")
-                continue
-            log_structured(trace_id, f"action_{action_type}", metadata={
-                "card_id": action.get("card_id", ""),
-            })
-        except Exception as e:
-            logger.error(f"[{trace_id}] Action {action_type} failed: {e}")
-            log_structured(trace_id, f"action_{action_type}", "failure", {
-                "error": str(e),
-            })
 
 
 SPEC_CONSOLIDATION_THRESHOLD = 14_000
@@ -757,8 +466,316 @@ def _create_card_with_checklist(trello, trace_id, list_name, card_data):
     return card
 
 
+# --- Agent ---
+
+
+COACH_TOOLS = [
+    {
+        "name": "read_card",
+        "description": "Read a card's full details: name, description, checklist items with IDs and completion states, and all comments with timestamps and Coach/Client roles.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "card_id": {"type": "string", "description": "Trello card ID"},
+            },
+            "required": ["card_id"],
+        },
+    },
+    {
+        "name": "archive_card",
+        "description": "Archive (close) a card.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "card_id": {"type": "string", "description": "Trello card ID"},
+            },
+            "required": ["card_id"],
+        },
+    },
+    {
+        "name": "check_item",
+        "description": "Check off a checklist item as complete.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "card_id": {"type": "string", "description": "Trello card ID"},
+                "item_id": {"type": "string", "description": "Checklist item ID"},
+            },
+            "required": ["card_id", "item_id"],
+        },
+    },
+    {
+        "name": "uncheck_item",
+        "description": "Uncheck a checklist item (mark incomplete).",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "card_id": {"type": "string", "description": "Trello card ID"},
+                "item_id": {"type": "string", "description": "Checklist item ID"},
+            },
+            "required": ["card_id", "item_id"],
+        },
+    },
+    {
+        "name": "move_card",
+        "description": "Move a card to a different list.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "card_id": {"type": "string", "description": "Trello card ID"},
+                "list_name": {
+                    "type": "string",
+                    "description": "Target list name (Exercise, Nutrition, Forum, or Memories)",
+                },
+            },
+            "required": ["card_id", "list_name"],
+        },
+    },
+    {
+        "name": "comment_on_card",
+        "description": "Add a comment to a card. Auto-prefixed with coach marker.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "card_id": {"type": "string", "description": "Trello card ID"},
+                "text": {"type": "string", "description": "Comment text"},
+            },
+            "required": ["card_id", "text"],
+        },
+    },
+    {
+        "name": "update_card",
+        "description": "Update a card's name and/or description.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "card_id": {"type": "string", "description": "Trello card ID"},
+                "name": {"type": "string", "description": "New card name"},
+                "desc": {"type": "string", "description": "New card description"},
+            },
+            "required": ["card_id"],
+        },
+    },
+    {
+        "name": "create_card",
+        "description": "Create a new card on a list with optional description, checklist, and comment.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "list_name": {
+                    "type": "string",
+                    "description": "List name (Exercise, Nutrition, Forum, or Memories)",
+                },
+                "title": {"type": "string", "description": "Card title"},
+                "description": {"type": "string", "description": "Card description"},
+                "checklist": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Checklist items",
+                },
+                "comment": {"type": "string", "description": "Initial comment on the card"},
+            },
+            "required": ["list_name", "title"],
+        },
+    },
+    {
+        "name": "update_spec",
+        "description": "Update the client spec (board description). Provide a brief plain-English instruction describing what to change.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "instruction": {
+                    "type": "string",
+                    "description": "Brief description of what to change in the spec",
+                },
+            },
+            "required": ["instruction"],
+        },
+    },
+    {
+        "name": "add_reaction",
+        "description": "React to a comment with an emoji.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "action_id": {"type": "string", "description": "Trello action (comment) ID"},
+                "emoji": {
+                    "type": "string",
+                    "description": "Emoji shortname (e.g. muscle, fire, thumbsup, heart)",
+                },
+            },
+            "required": ["action_id", "emoji"],
+        },
+    },
+]
+
+
+def execute_tool(trello, trace_id, tool_name, tool_input):
+    """Execute a tool call and return the result string. Errors returned as strings."""
+    try:
+        if tool_name == "read_card":
+            card_id = tool_input["card_id"]
+            card = trello.get_card(card_id)
+            lines = [f"### Card: {card['name']}"]
+            if card.get("desc"):
+                lines.append(card["desc"][:500])
+            try:
+                checklists = trello.get_card_checklists(card_id)
+                for cl in checklists:
+                    for item in cl.get("checkItems", []):
+                        state = "x" if item.get("state") == "complete" else " "
+                        lines.append(
+                            f"- [{state}] {item['name']}  (item_id: {item['id']})"
+                        )
+            except Exception:
+                pass
+            lines.append("")
+            comments = trello.get_card_comments(card_id)
+            for comment in comments:
+                ts = _utc_to_ct(comment.get("date", ""))
+                text = comment.get("data", {}).get("text", "")
+                role = _comment_role(text)
+                lines.append(f"[{ts}] {role}: {text}")
+            result = "\n".join(lines)
+            log_structured(trace_id, "tool_read_card", metadata={
+                "card_id": card_id, "length": len(result),
+            })
+            return result
+
+        elif tool_name == "archive_card":
+            trello.archive_card(tool_input["card_id"])
+            log_structured(trace_id, "tool_archive_card", metadata={
+                "card_id": tool_input["card_id"],
+            })
+            return "Card archived."
+
+        elif tool_name == "check_item":
+            trello.set_check_item_state(
+                tool_input["card_id"], tool_input["item_id"], "complete",
+            )
+            log_structured(trace_id, "tool_check_item", metadata={
+                "card_id": tool_input["card_id"], "item_id": tool_input["item_id"],
+            })
+            return "Item checked."
+
+        elif tool_name == "uncheck_item":
+            trello.set_check_item_state(
+                tool_input["card_id"], tool_input["item_id"], "incomplete",
+            )
+            log_structured(trace_id, "tool_uncheck_item", metadata={
+                "card_id": tool_input["card_id"], "item_id": tool_input["item_id"],
+            })
+            return "Item unchecked."
+
+        elif tool_name == "move_card":
+            list_id = trello.get_list_id(tool_input["list_name"])
+            trello.move_card(tool_input["card_id"], list_id)
+            log_structured(trace_id, "tool_move_card", metadata={
+                "card_id": tool_input["card_id"], "list": tool_input["list_name"],
+            })
+            return f"Card moved to {tool_input['list_name']}."
+
+        elif tool_name == "comment_on_card":
+            trello.add_comment(tool_input["card_id"], tool_input["text"])
+            log_structured(trace_id, "tool_comment", metadata={
+                "card_id": tool_input["card_id"], "length": len(tool_input["text"]),
+            })
+            return "Comment posted."
+
+        elif tool_name == "update_card":
+            fields = {}
+            if tool_input.get("name"):
+                fields["name"] = tool_input["name"]
+            if tool_input.get("desc"):
+                fields["desc"] = tool_input["desc"]
+            if fields:
+                trello.update_card(tool_input["card_id"], **fields)
+            log_structured(trace_id, "tool_update_card", metadata={
+                "card_id": tool_input["card_id"], "fields": list(fields.keys()),
+            })
+            return "Card updated."
+
+        elif tool_name == "create_card":
+            card = _create_card_with_checklist(trello, trace_id, tool_input["list_name"], {
+                "title": tool_input["title"],
+                "description": tool_input.get("description", ""),
+                "checklist": tool_input.get("checklist", []),
+                "comment": tool_input.get("comment", ""),
+            })
+            return f"Card created (card_id: {card['id']})."
+
+        elif tool_name == "update_spec":
+            current_spec = trello.get_board_desc()
+            _apply_spec_if_needed(trello, trace_id, current_spec, tool_input["instruction"])
+            return "Spec updated."
+
+        elif tool_name == "add_reaction":
+            trello.add_reaction(tool_input["action_id"], tool_input["emoji"])
+            log_structured(trace_id, "tool_add_reaction", metadata={
+                "action_id": tool_input["action_id"], "emoji": tool_input["emoji"],
+            })
+            return "Reaction added."
+
+        else:
+            return f"Unknown tool: {tool_name}"
+
+    except Exception as e:
+        logger.error(f"[{trace_id}] Tool {tool_name} failed: {e}")
+        return f"Error: {e}"
+
+
+def run_agent(client, trello, trace_id, system_prompt, user_message, tools=None):
+    """Run an agentic tool-use loop until the model stops or hits the iteration cap."""
+    if tools is None:
+        tools = COACH_TOOLS
+
+    messages = [{"role": "user", "content": user_message}]
+
+    for iteration in range(25):
+        response = client.messages.create(
+            model=MODEL,
+            max_tokens=8000,
+            system=system_prompt,
+            tools=tools,
+            messages=messages,
+        )
+
+        if response.stop_reason == "end_turn":
+            log_structured(trace_id, "agent_complete", metadata={
+                "iterations": iteration + 1,
+            })
+            return
+
+        if response.stop_reason != "tool_use":
+            log_structured(trace_id, "agent_stop", metadata={
+                "stop_reason": response.stop_reason,
+                "iterations": iteration + 1,
+            })
+            return
+
+        # Process tool calls
+        messages.append({"role": "assistant", "content": response.content})
+
+        tool_results = []
+        for block in response.content:
+            if block.type == "tool_use":
+                result = execute_tool(trello, trace_id, block.name, block.input)
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": block.id,
+                    "content": result,
+                })
+
+        messages.append({"role": "user", "content": tool_results})
+
+    log_structured(trace_id, "agent_max_iterations")
+
+
+# --- Handlers ---
+
+
 def handle_morning(trace_id):
-    """Generate and post daily exercise and nutrition cards."""
+    """Generate and post daily exercise and nutrition cards via agent loop."""
     try:
         trello = TrelloClient()
 
@@ -768,34 +785,67 @@ def handle_morning(trace_id):
         memories = read_memories(trello)
         log_structured(trace_id, "read_memories", metadata={"length": len(memories)})
 
-        board_context = read_board_context(trello)
-        log_structured(trace_id, "read_context", metadata={"length": len(board_context)})
+        board_summary = build_board_summary(trello)
+        log_structured(trace_id, "read_summary", metadata={"length": len(board_summary)})
 
-        result = generate_morning_cards(spec, board_context, memories)
+        now_ct = datetime.now(tz=CT)
+        day_of_week = now_ct.strftime("%A")
+        date_str = now_ct.strftime("%B %d, %Y")
+        time_str = now_ct.strftime("%-I:%M %p").lower()
 
-        log_structured(trace_id, "generate_morning", metadata={
-            "has_exercise": result.get("exercise") is not None,
-            "has_nutrition": result.get("nutrition") is not None,
-            "has_forum": result.get("forum") is not None,
-        })
+        system_prompt = f"""You are a muscle growth coach managing a client's training via a Trello board.
+Each morning you create cards for the day's training and nutrition.
 
-        # Create exercise card
-        if result.get("exercise"):
-            _create_card_with_checklist(trello, trace_id, "Exercise", result["exercise"])
+Today is {day_of_week}, {date_str}. Current time: {time_str} Central.
 
-        # Create nutrition card
-        if result.get("nutrition"):
-            _create_card_with_checklist(trello, trace_id, "Nutrition", result["nutrition"])
+## Board Structure
+- **Exercise** — one card per workout (title, routine in description, checklist of exercises)
+- **Nutrition** — cards for meals, grocery runs, supplements (title, description, checklist)
+- **Forum** — daily check-in card for open conversation throughout the day
+- **Memories** — long-term memory cards organized by category (one card per topic, comments are individual memories)
 
-        # Create forum check-in card
-        if result.get("forum"):
-            _create_card_with_checklist(trello, trace_id, "Forum", result["forum"])
+## Your Task
+1. Use read_card to inspect any recent cards that look relevant
+2. Archive old completed cards from previous days
+3. Create today's cards using create_card:
+   - Exercise card (skip on rest days): title like "{day_of_week}, {date_str} — [Focus Area]", description with full workout, checklist of exercises with weights/sets/reps, conversational comment
+   - Nutrition card: title like "{day_of_week}, {date_str} — Nutrition", description with meal plan, checklist of actionable items
+   - Forum check-in card: title like "{day_of_week}, {date_str} — Check In", conversational comment prompting the client
+4. Update the spec or add memories as needed
 
-        # Execute board actions
-        _execute_actions(trello, trace_id, result.get("actions", []))
+## Rules
+- Be specific to THEIR program — exercises, weights, sets, reps, rest periods
+- Include warm-up guidance if relevant
+- Exercise comments should be conversational and specific (not generic motivation)
+- Nutrition checklist items should be actionable (meals to eat, items to buy)
+- If the spec is empty, introduce yourself and ask what they're working on
+- On rest days, skip the exercise card but still provide nutrition and forum
+- The forum card is a daily check-in — open-ended prompt for the client
 
-        # Update spec if needed
-        _apply_spec_if_needed(trello, trace_id, spec, result.get("spec_update_instruction"))
+## Two-Tier Memory System
+**Spec** (board description) — your working document:
+- Current training program and schedule
+- Active goals and preferences
+- Plans and decisions that change over time
+- Update via update_spec tool. Prune stale info, compress daily details into trends.
+
+**Memories** (Memories list) — factual records that accumulate:
+- Personal records (PRs, body weight milestones), injury history, recovery notes
+- Key client info (schedule constraints, equipment access, dietary restrictions)
+- Use comment_on_card on an existing memory card, or create_card on the Memories list for a new category
+- Only store facts you'd actually reference later when coaching."""
+
+        user_message = f"""## Client Spec
+{spec or "(No spec yet — introduce yourself and ask about their goals)"}
+
+## Memories
+{memories or "(No memories yet)"}
+
+## Board Summary (use read_card to see full details)
+{board_summary or "(No cards on board — first interaction)"}"""
+
+        client = _get_client()
+        run_agent(client, trello, trace_id, system_prompt, user_message)
 
     except Exception as e:
         logger.error(f"[{trace_id}] Morning handler failed: {e}", exc_info=True)
@@ -804,7 +854,7 @@ def handle_morning(trace_id):
 
 
 def handle_reply(trace_id):
-    """Process user comment on a card and respond."""
+    """Process user comment on a card and respond via agent loop."""
     comment_text = os.getenv("COMMENT_TEXT", "")
     card_id = os.getenv("CARD_ID", "")
     action_id = os.getenv("ACTION_ID", "")
@@ -822,44 +872,88 @@ def handle_reply(trace_id):
         memories = read_memories(trello)
         log_structured(trace_id, "read_memories", metadata={"length": len(memories)})
 
-        board_context = read_board_context(trello)
+        board_summary = build_board_summary(trello)
+        log_structured(trace_id, "read_summary", metadata={"length": len(board_summary)})
+
+        # Pre-load the card being replied to (always relevant)
         card_context = read_card_context(trello, card_id)
         card = trello.get_card(card_id)
         card_name = card.get("name", "Unknown")
         log_structured(trace_id, "read_context", metadata={
             "card": card_name[:80],
-            "board_length": len(board_context),
+            "summary_length": len(board_summary),
             "card_length": len(card_context),
         })
 
-        result = generate_reply(spec, board_context, card_context, comment_text, card_name, memories)
+        now_ct = datetime.now(tz=CT)
+        day_of_week = now_ct.strftime("%A")
+        time_str = now_ct.strftime("%-I:%M %p").lower()
 
-        reply_text = result["message"]
-        log_structured(trace_id, "generate_reply", metadata={"length": len(reply_text)})
+        reaction_instruction = ""
+        if action_id:
+            reaction_instruction = (
+                f'\n4. React to their comment using '
+                f'add_reaction(action_id="{action_id}", emoji="...") '
+                f'with a fitting emoji (e.g. muscle, fire, thumbsup, heart, '
+                f'tada, eyes, thinking_face, clap)'
+            )
 
-        # React to the user's comment with the coach's chosen emoji
-        reaction = result.get("reaction", "")
-        if action_id and reaction:
-            try:
-                trello.add_reaction(action_id, reaction)
-            except Exception:
-                pass  # Non-critical
+        system_prompt = f"""You are a muscle growth coach communicating with your client via Trello card comments.
+Your client just commented on a card. Read their message and respond helpfully.
 
-        # Post reply
-        trello.add_comment(card_id, reply_text)
-        log_structured(trace_id, "add_comment", metadata={"length": len(reply_text)})
+Today is {day_of_week}. Current time: {time_str} Central.
 
-        # Execute board actions (skip comment actions on the reply card to avoid duplicates)
-        actions = [
-            a for a in result.get("actions", [])
-            if not (a.get("action") == "comment" and a.get("card_id") == card_id)
-        ]
-        _execute_actions(trello, trace_id, actions)
+## Board Structure
+- **Exercise** — workout cards (one per session)
+- **Nutrition** — meal plans, grocery lists, supplement tracking
+- **Forum** — ongoing discussion topics
+- **Memories** — long-term memory cards organized by category
 
-        # Update spec if needed
-        _apply_spec_if_needed(trello, trace_id, spec, result.get("spec_update_instruction"))
+## Your Task
+1. Understand what the client is telling you or asking
+2. Reply using comment_on_card on the card they commented on (card_id: {card_id})
+3. Take any other actions needed (check items, archive cards, create cards, update spec, add memories){reaction_instruction}
 
-        # React ✅ on user's comment as the very last step — signals job complete
+## Rules
+- Be conversational but knowledgeable
+- If they report a workout, acknowledge it specifically
+- If they ask a question, give a direct answer then brief explanation
+- If they share a concern (injury, plateau, motivation), address it with empathy and a plan
+- Use read_card to inspect other cards if you need more context
+- Use create_card when the client asks for a new workout plan, meal plan, grocery list, etc.
+
+## Two-Tier Memory System
+**Spec** (board description) — your working document:
+- Current training program and schedule
+- Active goals and preferences
+- Plans and decisions that change over time
+- Update via update_spec tool. Prune stale info, compress daily details into trends.
+
+**Memories** (Memories list) — factual records that accumulate:
+- Personal records (PRs, body weight milestones), injury history, recovery notes
+- Key client info (schedule constraints, equipment access, dietary restrictions)
+- Use comment_on_card on an existing memory card, or create_card on the Memories list for a new category
+- Only store facts you'd actually reference later when coaching."""
+
+        user_message = f"""## Client Spec
+{spec or "(No spec yet)"}
+
+## Memories
+{memories or "(No memories yet)"}
+
+## Board Summary (use read_card to see full details)
+{board_summary or "(No cards on board)"}
+
+## Card: {card_name} (card_id: {card_id})
+{card_context}
+
+## New Comment from Client
+{comment_text}"""
+
+        client = _get_client()
+        run_agent(client, trello, trace_id, system_prompt, user_message)
+
+        # React checkmark on user's comment as the very last step — signals job complete
         if action_id:
             try:
                 trello.add_reaction(action_id, "white_check_mark")

--- a/tests/test_coach.py
+++ b/tests/test_coach.py
@@ -17,49 +17,6 @@ coach = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(coach)
 
 
-class TestJsonParsing:
-    """Tests for _parse_json_response()."""
-
-    def test_clean_json(self):
-        result = coach._parse_json_response(
-            '{"message": "hello", "spec_updates": null}'
-        )
-        assert result["message"] == "hello"
-        assert result["spec_updates"] is None
-
-    def test_json_with_fences(self):
-        result = coach._parse_json_response(
-            '```json\n{"message": "hi", "spec_updates": null}\n```'
-        )
-        assert result["message"] == "hi"
-
-    def test_json_with_preamble(self):
-        result = coach._parse_json_response(
-            'Here is the response:\n{"message": "yo", "spec_updates": null}'
-        )
-        assert result["message"] == "yo"
-
-    def test_morning_cards_format(self):
-        result = coach._parse_json_response(json.dumps({
-            "exercise": {
-                "title": "Monday, Feb 6 — Push Day",
-                "description": "## Bench Press\n4x8 @ 185",
-                "checklist": ["Bench Press 4x8 @ 185"],
-                "comment": "Let's go!",
-            },
-            "nutrition": {
-                "title": "Monday, Feb 6 — Nutrition",
-                "description": "## Meals",
-                "checklist": ["Meal 1: Oatmeal + whey"],
-            },
-            "actions": [],
-            "spec_update_instruction": None,
-        }))
-        assert result["exercise"]["title"] == "Monday, Feb 6 — Push Day"
-        assert result["exercise"]["checklist"] == ["Bench Press 4x8 @ 185"]
-        assert result["nutrition"]["checklist"] == ["Meal 1: Oatmeal + whey"]
-
-
 class TestUtcToCt:
     """Tests for _utc_to_ct() timestamp conversion."""
 
@@ -77,71 +34,6 @@ class TestUtcToCt:
 
     def test_short_string(self):
         assert coach._utc_to_ct("2026") == "2026"
-
-
-class TestReadBoardContext:
-    """Tests for read_board_context()."""
-
-    def test_formats_cards_and_comments(self):
-        mock_trello = MagicMock()
-        mock_trello.get_lists.return_value = [
-            {"id": "list1", "name": "Exercise"},
-        ]
-        mock_trello.get_cards.return_value = [
-            {"id": "card1", "name": "Monday Push", "desc": "Bench day", "idList": "list1"},
-        ]
-        mock_trello.get_card_checklists.return_value = [
-            {"checkItems": [
-                {"id": "ci1", "name": "Bench 4x8", "state": "complete"},
-                {"id": "ci2", "name": "Incline 3x10", "state": "incomplete"},
-            ]},
-        ]
-        mock_trello.get_card_comments.return_value = [
-            {
-                "date": "2026-02-06T14:00:00",
-                "data": {"text": "Hit 225 on bench!"},
-            },
-            {
-                "date": "2026-02-06T14:05:00",
-                "data": {"text": "**[Coach]** Nice PR!"},
-            },
-        ]
-
-        result = coach.read_board_context(mock_trello)
-        assert "[Exercise] Monday Push" in result
-        assert "card_id: card1" in result
-        assert "[x] Bench 4x8" in result
-        assert "[ ] Incline 3x10" in result
-        assert "item_id: ci1" in result
-        assert "Client:" in result
-        assert "Coach:" in result
-        assert "Hit 225 on bench!" in result
-        assert "Nice PR!" in result
-
-    def test_empty_board(self):
-        mock_trello = MagicMock()
-        mock_trello.get_cards.return_value = []
-        mock_trello.get_lists.return_value = []
-
-        result = coach.read_board_context(mock_trello)
-        assert result == ""
-
-    def test_excludes_memories_cards(self):
-        mock_trello = MagicMock()
-        mock_trello.get_lists.return_value = [
-            {"id": "list1", "name": "Exercise"},
-            {"id": "mem_list", "name": "Memories"},
-        ]
-        mock_trello.get_cards.return_value = [
-            {"id": "c1", "name": "Push Day", "desc": "", "idList": "list1"},
-            {"id": "c2", "name": "PRs", "desc": "", "idList": "mem_list"},
-        ]
-        mock_trello.get_card_checklists.return_value = []
-        mock_trello.get_card_comments.return_value = []
-
-        result = coach.read_board_context(mock_trello)
-        assert "Push Day" in result
-        assert "PRs" not in result
 
 
 class TestReadMemories:
@@ -219,6 +111,50 @@ class TestReadCardContext:
         assert "Feeling sore" in result
 
 
+class TestBuildBoardSummary:
+    """Tests for build_board_summary()."""
+
+    def test_formats_cards_with_list_and_activity(self):
+        mock_trello = MagicMock()
+        mock_trello.get_lists.return_value = [
+            {"id": "list1", "name": "Exercise"},
+        ]
+        mock_trello.get_cards.return_value = [
+            {
+                "id": "c1", "name": "Push Day", "idList": "list1",
+                "dateLastActivity": "2026-02-06T14:00:00.000Z",
+            },
+        ]
+
+        result = coach.build_board_summary(mock_trello)
+        assert "[Exercise] Push Day" in result
+        assert "card_id: c1" in result
+        assert "last_activity:" in result
+
+    def test_excludes_memories_cards(self):
+        mock_trello = MagicMock()
+        mock_trello.get_lists.return_value = [
+            {"id": "list1", "name": "Exercise"},
+            {"id": "mem_list", "name": "Memories"},
+        ]
+        mock_trello.get_cards.return_value = [
+            {"id": "c1", "name": "Push Day", "idList": "list1", "dateLastActivity": ""},
+            {"id": "c2", "name": "PRs", "idList": "mem_list", "dateLastActivity": ""},
+        ]
+
+        result = coach.build_board_summary(mock_trello)
+        assert "Push Day" in result
+        assert "PRs" not in result
+
+    def test_empty_board(self):
+        mock_trello = MagicMock()
+        mock_trello.get_lists.return_value = []
+        mock_trello.get_cards.return_value = []
+
+        result = coach.build_board_summary(mock_trello)
+        assert result == ""
+
+
 def _mock_api_response(text):
     """Create a mock Anthropic API response with the given text."""
     block = MagicMock()
@@ -226,75 +162,6 @@ def _mock_api_response(text):
     resp = MagicMock()
     resp.content = [block]
     return resp
-
-
-class TestGenerateMorningCards:
-    """Tests for generate_morning_cards()."""
-
-    @patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"})
-    @patch.object(coach.anthropic, "Anthropic")
-    def test_returns_cards(self, mock_cls):
-        mock_client = MagicMock()
-        mock_cls.return_value = mock_client
-        mock_client.messages.create.return_value = _mock_api_response(
-            json.dumps({
-                "exercise": {
-                    "title": "Monday — Push Day",
-                    "description": "## Bench\n4x8",
-                    "checklist": ["Bench 4x8"],
-                    "comment": "Let's go!",
-                },
-                "nutrition": {
-                    "title": "Monday — Nutrition",
-                    "description": "## Meals",
-                    "checklist": ["Meal 1: Oatmeal"],
-                },
-                "actions": [],
-                "spec_update_instruction": None,
-            })
-        )
-        result = coach.generate_morning_cards("# Spec\nGoals: gain muscle", "")
-        assert result["exercise"]["title"] == "Monday — Push Day"
-        assert result["exercise"]["checklist"] == ["Bench 4x8"]
-        assert result["nutrition"]["checklist"] == ["Meal 1: Oatmeal"]
-        assert result["spec_update_instruction"] is None
-        assert mock_client.messages.create.call_args[1]["model"] == "claude-opus-4-6"
-
-
-class TestGenerateReply:
-    """Tests for generate_reply()."""
-
-    @patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"})
-    @patch.object(coach.anthropic, "Anthropic")
-    def test_reply_without_spec_update(self, mock_cls):
-        mock_client = MagicMock()
-        mock_cls.return_value = mock_client
-        mock_client.messages.create.return_value = _mock_api_response(
-            json.dumps({
-                "message": "Nice work!",
-                "actions": [],
-                "spec_update_instruction": None,
-            })
-        )
-        result = coach.generate_reply("# Spec", "", "", "Did 3x10 bench at 185", "Push Day")
-        assert result["message"] == "Nice work!"
-        assert result["spec_update_instruction"] is None
-
-    @patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"})
-    @patch.object(coach.anthropic, "Anthropic")
-    def test_reply_with_spec_update_instruction(self, mock_cls):
-        mock_client = MagicMock()
-        mock_cls.return_value = mock_client
-        mock_client.messages.create.return_value = _mock_api_response(
-            json.dumps({
-                "message": "225 5x5 is huge!",
-                "actions": [],
-                "spec_update_instruction": "Update squat PR to 225x5x5",
-            })
-        )
-        result = coach.generate_reply("# Spec", "", "", "Hit 225 for 5x5!", "Leg Day")
-        assert result["spec_update_instruction"] is not None
-        assert "225" in result["spec_update_instruction"]
 
 
 class TestApplySpecUpdate:
@@ -326,217 +193,352 @@ class TestApplySpecUpdate:
         assert result == "# Spec\nUpdated"
 
 
-class TestExecuteActions:
-    """Tests for _execute_actions()."""
+class TestExecuteTool:
+    """Tests for execute_tool()."""
 
-    def test_check_item(self):
+    def test_read_card(self):
         mock_trello = MagicMock()
-        coach._execute_actions(mock_trello, "t1", [
-            {"action": "check_item", "card_id": "c1", "item_id": "i1"},
-        ])
-        mock_trello.set_check_item_state.assert_called_once_with("c1", "i1", "complete")
+        mock_trello.get_card.return_value = {"name": "Push Day", "desc": "Bench"}
+        mock_trello.get_card_checklists.return_value = [
+            {"checkItems": [
+                {"id": "i1", "name": "Bench 4x8", "state": "complete"},
+                {"id": "i2", "name": "Incline 3x10", "state": "incomplete"},
+            ]},
+        ]
+        mock_trello.get_card_comments.return_value = [
+            {"date": "2026-02-06T14:00:00", "data": {"text": "Done!"}},
+        ]
 
-    def test_uncheck_item(self):
-        mock_trello = MagicMock()
-        coach._execute_actions(mock_trello, "t1", [
-            {"action": "uncheck_item", "card_id": "c1", "item_id": "i1"},
-        ])
-        mock_trello.set_check_item_state.assert_called_once_with("c1", "i1", "incomplete")
+        result = coach.execute_tool(mock_trello, "t1", "read_card", {"card_id": "c1"})
+        assert "Push Day" in result
+        assert "[x] Bench 4x8" in result
+        assert "[ ] Incline 3x10" in result
+        assert "item_id: i1" in result
+        assert "Done!" in result
 
     def test_archive_card(self):
         mock_trello = MagicMock()
-        coach._execute_actions(mock_trello, "t1", [
-            {"action": "archive_card", "card_id": "c1"},
-        ])
+        result = coach.execute_tool(mock_trello, "t1", "archive_card", {"card_id": "c1"})
         mock_trello.archive_card.assert_called_once_with("c1")
+        assert "archived" in result.lower()
+
+    def test_check_item(self):
+        mock_trello = MagicMock()
+        result = coach.execute_tool(
+            mock_trello, "t1", "check_item", {"card_id": "c1", "item_id": "i1"},
+        )
+        mock_trello.set_check_item_state.assert_called_once_with("c1", "i1", "complete")
+        assert "checked" in result.lower()
+
+    def test_uncheck_item(self):
+        mock_trello = MagicMock()
+        result = coach.execute_tool(
+            mock_trello, "t1", "uncheck_item", {"card_id": "c1", "item_id": "i1"},
+        )
+        mock_trello.set_check_item_state.assert_called_once_with("c1", "i1", "incomplete")
+        assert "unchecked" in result.lower()
 
     def test_move_card(self):
         mock_trello = MagicMock()
         mock_trello.get_list_id.return_value = "list_exercise"
-        coach._execute_actions(mock_trello, "t1", [
-            {"action": "move_card", "card_id": "c1", "list": "Exercise"},
-        ])
+        result = coach.execute_tool(
+            mock_trello, "t1", "move_card", {"card_id": "c1", "list_name": "Exercise"},
+        )
         mock_trello.move_card.assert_called_once_with("c1", "list_exercise")
+        assert "Exercise" in result
 
-    def test_comment(self):
+    def test_comment_on_card(self):
         mock_trello = MagicMock()
-        coach._execute_actions(mock_trello, "t1", [
-            {"action": "comment", "card_id": "c1", "text": "Great job"},
-        ])
-        mock_trello.add_comment.assert_called_once_with("c1", "Great job")
+        result = coach.execute_tool(
+            mock_trello, "t1", "comment_on_card", {"card_id": "c1", "text": "Nice!"},
+        )
+        mock_trello.add_comment.assert_called_once_with("c1", "Nice!")
+        assert "posted" in result.lower()
 
     def test_update_card(self):
         mock_trello = MagicMock()
-        coach._execute_actions(mock_trello, "t1", [
-            {"action": "update_card", "card_id": "c1", "name": "New Name", "desc": "New desc"},
-        ])
+        result = coach.execute_tool(
+            mock_trello, "t1", "update_card",
+            {"card_id": "c1", "name": "New Name", "desc": "New desc"},
+        )
         mock_trello.update_card.assert_called_once_with("c1", name="New Name", desc="New desc")
+        assert "updated" in result.lower()
 
     def test_create_card(self):
         mock_trello = MagicMock()
-        mock_trello.get_list_id.return_value = "list_nutrition"
+        mock_trello.get_list_id.return_value = "list_exercise"
         mock_trello.create_card.return_value = {"id": "new_card"}
-        mock_trello.create_checklist.return_value = {"id": "cl_1"}
-        coach._execute_actions(mock_trello, "t1", [
-            {
-                "action": "create_card",
-                "list": "Nutrition",
-                "title": "Grocery Run",
-                "description": "Weekly groceries",
-                "checklist": ["Chicken breast", "Rice", "Broccoli"],
-                "comment": "Stock up!",
-            },
-        ])
-        mock_trello.create_card.assert_called_once_with(
-            "list_nutrition", "Grocery Run", "Weekly groceries",
-        )
-        assert mock_trello.add_checklist_item.call_count == 3
-        mock_trello.add_comment.assert_called_once_with("new_card", "Stock up!")
+        mock_trello.create_checklist.return_value = {"id": "cl1"}
+        result = coach.execute_tool(mock_trello, "t1", "create_card", {
+            "list_name": "Exercise",
+            "title": "Leg Day",
+            "description": "Squats",
+            "checklist": ["Squat 4x8"],
+            "comment": "Go heavy!",
+        })
+        mock_trello.create_card.assert_called_once()
+        assert "new_card" in result
 
     def test_create_card_minimal(self):
         mock_trello = MagicMock()
         mock_trello.get_list_id.return_value = "list_exercise"
         mock_trello.create_card.return_value = {"id": "new_card"}
-        coach._execute_actions(mock_trello, "t1", [
-            {"action": "create_card", "list": "Exercise", "title": "Leg Day"},
-        ])
-        mock_trello.create_card.assert_called_once_with(
-            "list_exercise", "Leg Day", "",
-        )
+        result = coach.execute_tool(mock_trello, "t1", "create_card", {
+            "list_name": "Exercise",
+            "title": "Leg Day",
+        })
+        mock_trello.create_card.assert_called_once()
         mock_trello.create_checklist.assert_not_called()
         mock_trello.add_comment.assert_not_called()
 
-    def test_multiple_actions(self):
+    @patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"})
+    @patch.object(coach.anthropic, "Anthropic")
+    def test_update_spec(self, mock_cls):
         mock_trello = MagicMock()
-        mock_trello.get_list_id.return_value = "list_forum"
-        coach._execute_actions(mock_trello, "t1", [
-            {"action": "check_item", "card_id": "c1", "item_id": "i1"},
-            {"action": "archive_card", "card_id": "c2"},
-            {"action": "move_card", "card_id": "c3", "list": "Forum"},
-        ])
-        mock_trello.set_check_item_state.assert_called_once()
-        mock_trello.archive_card.assert_called_once_with("c2")
-        mock_trello.move_card.assert_called_once_with("c3", "list_forum")
+        mock_trello.get_board_desc.return_value = "# Spec"
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.messages.create.return_value = _mock_api_response("# Updated Spec")
 
-    def test_action_failure_continues(self):
+        result = coach.execute_tool(
+            mock_trello, "t1", "update_spec", {"instruction": "Add PR"},
+        )
+        assert "updated" in result.lower()
+        mock_trello.update_board_desc.assert_called_once()
+
+    def test_add_reaction(self):
+        mock_trello = MagicMock()
+        result = coach.execute_tool(
+            mock_trello, "t1", "add_reaction",
+            {"action_id": "a1", "emoji": "muscle"},
+        )
+        mock_trello.add_reaction.assert_called_once_with("a1", "muscle")
+        assert "reaction" in result.lower()
+
+    def test_tool_error_returns_string(self):
         mock_trello = MagicMock()
         mock_trello.archive_card.side_effect = Exception("API error")
-        # Should not raise — logs error and continues
-        coach._execute_actions(mock_trello, "t1", [
-            {"action": "archive_card", "card_id": "c1"},
-            {"action": "check_item", "card_id": "c2", "item_id": "i1"},
-        ])
-        # Second action still executed despite first failing
-        mock_trello.set_check_item_state.assert_called_once()
+        result = coach.execute_tool(mock_trello, "t1", "archive_card", {"card_id": "c1"})
+        assert "Error:" in result
 
-    def test_empty_actions(self):
+    def test_unknown_tool(self):
         mock_trello = MagicMock()
-        coach._execute_actions(mock_trello, "t1", [])
-        # No Trello calls made
-        mock_trello.assert_not_called()
+        result = coach.execute_tool(mock_trello, "t1", "unknown_tool", {})
+        assert "Unknown tool" in result
+
+
+class TestRunAgent:
+    """Tests for run_agent()."""
+
+    def test_single_turn_end(self):
+        """Agent that ends immediately without tools."""
+        mock_client = MagicMock()
+        mock_trello = MagicMock()
+
+        response = MagicMock()
+        response.stop_reason = "end_turn"
+        response.content = [MagicMock(type="text", text="Done")]
+        mock_client.messages.create.return_value = response
+
+        coach.run_agent(mock_client, mock_trello, "t1", "system", "user")
+        assert mock_client.messages.create.call_count == 1
+
+    def test_tool_use_then_end(self):
+        """Agent that uses a tool then ends."""
+        mock_client = MagicMock()
+        mock_trello = MagicMock()
+        mock_trello.archive_card.return_value = {}
+
+        # First response: tool_use
+        tool_block = MagicMock()
+        tool_block.type = "tool_use"
+        tool_block.id = "tu_1"
+        tool_block.name = "archive_card"
+        tool_block.input = {"card_id": "c1"}
+
+        first_response = MagicMock()
+        first_response.stop_reason = "tool_use"
+        first_response.content = [tool_block]
+
+        # Second response: end_turn
+        second_response = MagicMock()
+        second_response.stop_reason = "end_turn"
+        second_response.content = [MagicMock(type="text", text="Done")]
+
+        mock_client.messages.create.side_effect = [first_response, second_response]
+
+        coach.run_agent(mock_client, mock_trello, "t1", "system", "user")
+
+        assert mock_client.messages.create.call_count == 2
+        mock_trello.archive_card.assert_called_once_with("c1")
+
+    def test_max_iterations_cap(self):
+        """Agent that loops forever hits the 25-iteration cap."""
+        mock_client = MagicMock()
+        mock_trello = MagicMock()
+        mock_trello.archive_card.return_value = {}
+
+        tool_block = MagicMock()
+        tool_block.type = "tool_use"
+        tool_block.id = "tu_1"
+        tool_block.name = "archive_card"
+        tool_block.input = {"card_id": "c1"}
+
+        response = MagicMock()
+        response.stop_reason = "tool_use"
+        response.content = [tool_block]
+
+        mock_client.messages.create.return_value = response
+
+        coach.run_agent(mock_client, mock_trello, "t1", "system", "user")
+        assert mock_client.messages.create.call_count == 25
+
+    def test_unexpected_stop_reason(self):
+        """Agent handles unexpected stop reasons gracefully."""
+        mock_client = MagicMock()
+        mock_trello = MagicMock()
+
+        response = MagicMock()
+        response.stop_reason = "max_tokens"
+        response.content = [MagicMock(type="text", text="truncated")]
+        mock_client.messages.create.return_value = response
+
+        coach.run_agent(mock_client, mock_trello, "t1", "system", "user")
+        assert mock_client.messages.create.call_count == 1
+
+    def test_multi_step_read_then_create(self):
+        """Agent reads a card, then creates a new card, then ends."""
+        mock_client = MagicMock()
+        mock_trello = MagicMock()
+        mock_trello.get_card.return_value = {"name": "Old Card", "desc": "Details"}
+        mock_trello.get_card_checklists.return_value = []
+        mock_trello.get_card_comments.return_value = []
+        mock_trello.get_list_id.return_value = "list_exercise"
+        mock_trello.create_card.return_value = {"id": "new_card_1"}
+
+        # Turn 1: read_card
+        read_block = MagicMock()
+        read_block.type = "tool_use"
+        read_block.id = "tu_1"
+        read_block.name = "read_card"
+        read_block.input = {"card_id": "c1"}
+        resp1 = MagicMock(stop_reason="tool_use", content=[read_block])
+
+        # Turn 2: create_card
+        create_block = MagicMock()
+        create_block.type = "tool_use"
+        create_block.id = "tu_2"
+        create_block.name = "create_card"
+        create_block.input = {"list_name": "Exercise", "title": "Push Day"}
+        resp2 = MagicMock(stop_reason="tool_use", content=[create_block])
+
+        # Turn 3: done
+        resp3 = MagicMock(stop_reason="end_turn")
+        resp3.content = [MagicMock(type="text", text="All done")]
+
+        mock_client.messages.create.side_effect = [resp1, resp2, resp3]
+
+        coach.run_agent(mock_client, mock_trello, "t1", "system prompt", "user msg")
+
+        assert mock_client.messages.create.call_count == 3
+        mock_trello.get_card.assert_called_once_with("c1")
+        mock_trello.create_card.assert_called_once()
+        # Verify message threading: 3rd call should have 5 messages
+        # (user, assistant+tool_use, tool_result, assistant+tool_use, tool_result)
+        third_call_messages = mock_client.messages.create.call_args_list[2][1]["messages"]
+        assert len(third_call_messages) == 5
+        assert third_call_messages[0]["role"] == "user"
+        assert third_call_messages[1]["role"] == "assistant"
+        assert third_call_messages[2]["role"] == "user"  # tool_result
+        assert third_call_messages[3]["role"] == "assistant"
+        assert third_call_messages[4]["role"] == "user"  # tool_result
+
+    def test_parallel_tool_use(self):
+        """Agent calls two tools in one response (comment + reaction)."""
+        mock_client = MagicMock()
+        mock_trello = MagicMock()
+
+        comment_block = MagicMock()
+        comment_block.type = "tool_use"
+        comment_block.id = "tu_1"
+        comment_block.name = "comment_on_card"
+        comment_block.input = {"card_id": "c1", "text": "Nice work!"}
+        reaction_block = MagicMock()
+        reaction_block.type = "tool_use"
+        reaction_block.id = "tu_2"
+        reaction_block.name = "add_reaction"
+        reaction_block.input = {"action_id": "a1", "emoji": "muscle"}
+
+        resp1 = MagicMock(stop_reason="tool_use", content=[comment_block, reaction_block])
+        resp2 = MagicMock(stop_reason="end_turn")
+        resp2.content = [MagicMock(type="text", text="Done")]
+
+        mock_client.messages.create.side_effect = [resp1, resp2]
+
+        coach.run_agent(mock_client, mock_trello, "t1", "system", "user")
+
+        assert mock_client.messages.create.call_count == 2
+        mock_trello.add_comment.assert_called_once_with("c1", "Nice work!")
+        mock_trello.add_reaction.assert_called_once_with("a1", "muscle")
+        # Both tool results sent back in one message
+        second_call_messages = mock_client.messages.create.call_args_list[1][1]["messages"]
+        tool_result_msg = second_call_messages[2]
+        assert tool_result_msg["role"] == "user"
+        assert len(tool_result_msg["content"]) == 2
+        assert tool_result_msg["content"][0]["tool_use_id"] == "tu_1"
+        assert tool_result_msg["content"][1]["tool_use_id"] == "tu_2"
+
+    def test_tool_error_flows_back_to_llm(self):
+        """Tool failure returns error string; LLM sees it and ends."""
+        mock_client = MagicMock()
+        mock_trello = MagicMock()
+        mock_trello.archive_card.side_effect = Exception("Card not found")
+
+        tool_block = MagicMock()
+        tool_block.type = "tool_use"
+        tool_block.id = "tu_1"
+        tool_block.name = "archive_card"
+        tool_block.input = {"card_id": "bad_id"}
+        resp1 = MagicMock(stop_reason="tool_use", content=[tool_block])
+
+        resp2 = MagicMock(stop_reason="end_turn")
+        resp2.content = [MagicMock(type="text", text="That card doesn't exist")]
+
+        mock_client.messages.create.side_effect = [resp1, resp2]
+
+        coach.run_agent(mock_client, mock_trello, "t1", "system", "user")
+
+        assert mock_client.messages.create.call_count == 2
+        # Verify error string was sent back as tool_result
+        second_call_messages = mock_client.messages.create.call_args_list[1][1]["messages"]
+        tool_result_content = second_call_messages[2]["content"][0]["content"]
+        assert "Error:" in tool_result_content
+        assert "Card not found" in tool_result_content
 
 
 class TestHandleMorning:
     """Tests for handle_morning()."""
 
     @patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"})
+    @patch.object(coach, "run_agent")
+    @patch.object(coach, "_get_client")
     @patch.object(coach, "TrelloClient")
-    @patch.object(coach.anthropic, "Anthropic")
-    def test_creates_exercise_and_nutrition_cards(self, mock_api_cls, mock_trello_cls):
+    def test_calls_run_agent_with_context(self, mock_trello_cls, mock_get_client, mock_run_agent):
         mock_trello = MagicMock()
         mock_trello_cls.return_value = mock_trello
         mock_trello.get_board_desc.return_value = "# Spec"
         mock_trello.get_cards.return_value = []
         mock_trello.get_lists.return_value = []
-        mock_trello.get_list_id.side_effect = lambda name: f"list_{name.lower()}"
-        mock_trello.create_card.side_effect = [
-            {"id": "exercise_card"},
-            {"id": "nutrition_card"},
-            {"id": "forum_card"},
-        ]
-        mock_trello.create_checklist.side_effect = [
-            {"id": "cl_exercise"},
-            {"id": "cl_nutrition"},
-        ]
-
-        mock_client = MagicMock()
-        mock_api_cls.return_value = mock_client
-        mock_client.messages.create.return_value = _mock_api_response(
-            json.dumps({
-                "exercise": {
-                    "title": "Monday — Push Day",
-                    "description": "## Bench\n4x8 @ 185",
-                    "checklist": ["Bench 4x8 @ 185", "Incline DB 3x10 @ 70"],
-                    "comment": "Time to push!",
-                },
-                "nutrition": {
-                    "title": "Monday — Nutrition",
-                    "description": "## Meals",
-                    "checklist": ["Meal 1: Oatmeal + whey"],
-                },
-                "forum": {
-                    "title": "Monday — Check In",
-                    "description": "",
-                    "comment": "How are you feeling today?",
-                },
-                "actions": [],
-                "spec_update_instruction": None,
-            })
-        )
 
         coach.handle_morning("trace-1")
 
-        assert mock_trello.create_card.call_count == 3
-        # Exercise card
-        mock_trello.create_card.assert_any_call(
-            "list_exercise", "Monday — Push Day", "## Bench\n4x8 @ 185",
-        )
-        # Nutrition card
-        mock_trello.create_card.assert_any_call(
-            "list_nutrition", "Monday — Nutrition", "## Meals",
-        )
-        # Forum card
-        mock_trello.create_card.assert_any_call(
-            "list_forum", "Monday — Check In", "",
-        )
-        assert mock_trello.add_checklist_item.call_count == 3  # 2 exercise + 1 nutrition
-        # Exercise comment + forum comment
-        assert mock_trello.add_comment.call_count == 2
-
-    @patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"})
-    @patch.object(coach, "TrelloClient")
-    @patch.object(coach.anthropic, "Anthropic")
-    def test_skips_null_cards(self, mock_api_cls, mock_trello_cls):
-        mock_trello = MagicMock()
-        mock_trello_cls.return_value = mock_trello
-        mock_trello.get_board_desc.return_value = "# Spec"
-        mock_trello.get_cards.return_value = []
-        mock_trello.get_lists.return_value = []
-
-        mock_client = MagicMock()
-        mock_api_cls.return_value = mock_client
-        mock_client.messages.create.return_value = _mock_api_response(
-            json.dumps({
-                "exercise": None,
-                "nutrition": {
-                    "title": "Rest Day — Nutrition",
-                    "description": "Recovery meals",
-                    "checklist": ["High protein meals"],
-                },
-                "actions": [],
-                "spec_update_instruction": None,
-            })
-        )
-
-        mock_trello.get_list_id.side_effect = lambda name: f"list_{name.lower()}"
-        mock_trello.create_card.return_value = {"id": "nutr_card"}
-        mock_trello.create_checklist.return_value = {"id": "cl_1"}
-
-        coach.handle_morning("trace-2")
-
-        # Only nutrition card created
-        mock_trello.create_card.assert_called_once()
-        mock_trello.move_card.assert_not_called()
+        mock_run_agent.assert_called_once()
+        call_args = mock_run_agent.call_args[0]
+        system_prompt = call_args[3]
+        user_message = call_args[4]
+        assert "coach" in system_prompt.lower()
+        assert "create_card" in system_prompt
+        assert "# Spec" in user_message
 
 
 class TestHandleReply:
@@ -546,39 +548,62 @@ class TestHandleReply:
         "ANTHROPIC_API_KEY": "test-key",
         "COMMENT_TEXT": "Hit 225 on squats today",
         "CARD_ID": "card_abc",
+        "ACTION_ID": "action_123",
     })
+    @patch.object(coach, "run_agent")
+    @patch.object(coach, "_get_client")
     @patch.object(coach, "TrelloClient")
-    @patch.object(coach.anthropic, "Anthropic")
-    def test_replies_to_comment(self, mock_api_cls, mock_trello_cls):
+    def test_calls_run_agent_and_reacts(self, mock_trello_cls, mock_get_client, mock_run_agent):
         mock_trello = MagicMock()
         mock_trello_cls.return_value = mock_trello
         mock_trello.get_board_desc.return_value = "# Spec"
-        mock_trello.get_lists.return_value = []
         mock_trello.get_cards.return_value = []
-        mock_trello.get_card.return_value = {"name": "Monday — Push", "desc": "Bench day"}
+        mock_trello.get_lists.return_value = []
+        mock_trello.get_card.return_value = {"name": "Leg Day", "desc": "Squats"}
         mock_trello.get_card_comments.return_value = []
-
-        mock_client = MagicMock()
-        mock_api_cls.return_value = mock_client
-        # First call: generate_reply (Opus), second call: apply_spec_update (Haiku)
-        mock_client.messages.create.side_effect = [
-            _mock_api_response(json.dumps({
-                "message": "225 is a huge PR!",
-                "actions": [{"action": "check_item", "card_id": "card_abc", "item_id": "ci1"}],
-                "spec_update_instruction": "Update squat PR to 225x5x5",
-            })),
-            _mock_api_response("# Updated\n- Squat: 225"),
-        ]
 
         coach.handle_reply("trace-3")
 
-        mock_trello.add_comment.assert_called_once_with(
-            "card_abc", "225 is a huge PR!"
-        )
-        # Check item action executed
-        mock_trello.set_check_item_state.assert_called_once_with("card_abc", "ci1", "complete")
-        # Spec updated via Haiku
-        mock_trello.update_board_desc.assert_called_once_with("# Updated\n- Squat: 225")
+        mock_run_agent.assert_called_once()
+        call_args = mock_run_agent.call_args[0]
+        system_prompt = call_args[3]
+        user_message = call_args[4]
+        assert "coach" in system_prompt.lower()
+        assert "comment_on_card" in system_prompt
+        assert "card_abc" in system_prompt
+        assert "add_reaction" in system_prompt
+        assert "action_123" in system_prompt
+        assert "Hit 225" in user_message
+        assert "card_abc" in user_message
+        # Checkmark reaction added after agent completes
+        mock_trello.add_reaction.assert_called_once_with("action_123", "white_check_mark")
+
+    @patch.dict("os.environ", {
+        "ANTHROPIC_API_KEY": "test-key",
+        "COMMENT_TEXT": "Hello",
+        "CARD_ID": "card_abc",
+        "ACTION_ID": "",
+    })
+    @patch.object(coach, "run_agent")
+    @patch.object(coach, "_get_client")
+    @patch.object(coach, "TrelloClient")
+    def test_skips_reaction_without_action_id(self, mock_trello_cls, mock_get_client, mock_run_agent):
+        mock_trello = MagicMock()
+        mock_trello_cls.return_value = mock_trello
+        mock_trello.get_board_desc.return_value = "# Spec"
+        mock_trello.get_cards.return_value = []
+        mock_trello.get_lists.return_value = []
+        mock_trello.get_card.return_value = {"name": "Forum", "desc": ""}
+        mock_trello.get_card_comments.return_value = []
+
+        coach.handle_reply("trace-5")
+
+        mock_run_agent.assert_called_once()
+        # No add_reaction instruction in system prompt
+        system_prompt = mock_run_agent.call_args[0][3]
+        assert "add_reaction" not in system_prompt
+        # No reaction call
+        mock_trello.add_reaction.assert_not_called()
 
     @patch.dict("os.environ", {"COMMENT_TEXT": "", "CARD_ID": ""})
     def test_skips_empty_comment(self):


### PR DESCRIPTION
## Summary
- Replace JSON-output approach with agentic tool-use loop — the LLM now gets a lightweight board summary (card titles + IDs) and reads individual cards on demand via `read_card`, instead of dumping all descriptions/comments/checklists into every call
- Add 10 tools (read_card, archive_card, check_item, uncheck_item, move_card, comment_on_card, update_card, create_card, update_spec, add_reaction) with `run_agent()` loop (25-iteration cap)
- Remove dead code: `read_board_context`, `_parse_json_response`, `generate_morning_cards`, `generate_reply`, `_execute_actions`

## Test plan
- [x] `make validate` passes (127 tests, lint clean)
- [ ] Verify morning mode creates cards correctly in staging
- [ ] Verify reply mode responds to comments correctly in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)