### PR TITLE
Classify personalized property reports as 'other', not marketing

### DIFF
--- a/cloud-run/email-processor/main.py
+++ b/cloud-run/email-processor/main.py
@@ -233,6 +233,9 @@ def classify_email(subject: str, sender: str, body: str) -> dict:
   account security alerts, credit monitoring alerts indicating significant changes (score drops, new accounts),
   direct messages from real people, direct social media comments from real people (they warrant response),
   calendar invites, support responses, shared files/passes to download, health portal messages,
+  personalized reports or updates from a real person (e.g., a real estate agent) about the recipient's
+  own property, accounts, or affairs—such as a home value report—even if that person works in sales;
+  the personalized, individually-relevant content makes it 'other', not 'marketing',
   notifications that enable taking action or require review.
 
 Email:


### PR DESCRIPTION
## Summary

Fixes #18.

Emails like the real estate agent Michael Hamner's **"Your new Home Value Report is Ready!"** were being classified as `marketing`, which meant they got labeled and archived out of the inbox. As the issue notes, these should be **"no label"** — left untouched in the inbox.

In the email processor, only `marketing` and `noti` result in a label + archive. The `other` category takes **no action**, so "no label" maps to classifying these as `other`.

## Change

Refined the classification prompt in `cloud-run/email-processor/main.py` so that **personalized reports/updates from a real person about the recipient's own property, accounts, or affairs** (e.g., a home value report from a real estate agent) are classified as `other` — even when the sender works in sales. The personalized, individually-relevant nature of the content is what distinguishes it from bulk `marketing`.

This is prompt-only; there is no sender-allowlist mechanism in the current architecture, and classification is entirely prompt-driven.

## Testing

- `uv run ruff check cloud-run/email-processor/main.py` — passes.

There is no existing automated test suite for the email classifier prompt, so no tests were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157Uwt7CJboSytWTaz5NxW4

---
_Generated by [Claude Code](https://claude.ai/code/session_0157Uwt7CJboSytWTaz5NxW4)_